### PR TITLE
fix: kyverno unavailible charts issue and add policy reporter

### DIFF
--- a/kyverno/kyverno-policies.yaml
+++ b/kyverno/kyverno-policies.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     chart: kyverno-policies
-    repoURL: https://kubeshop.github.io/helm-charts
+    repoURL: https://kyverno.github.io/kyverno
     targetRevision: v2.5.5
     helm:
       releaseName: kyverno-policies

--- a/kyverno/kyverno.yaml
+++ b/kyverno/kyverno.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     chart: kyverno
-    repoURL: https://kubeshop.github.io/helm-charts
+    repoURL: https://kyverno.github.io/kyverno
     targetRevision: v3.0.0
     helm:
       releaseName: kyverno

--- a/kyverno/policy-reporter.yaml
+++ b/kyverno/policy-reporter.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: policy-reporter
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: kyverno
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: policy-reporter
+    repoURL: https://kyverno.github.io/policy-reporter
+    targetRevision: v2.19.4
+    helm:
+      releaseName: policy-reporter
+      values: |
+        ui:
+          enabled: true
+        kyvernoPlugin:
+          enabled: true
+        metrics:
+          enabled: true
+        global:
+          # available plugins
+          plugins:
+            # enable kyverno for Policy Reporter UI and monitoring
+            kyverno: true
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Currently, in these files exist an incorrect repoURL source for kyverno&kyverno-policies charts, argocd returned errors during sync for this application.

Also added policy-reporter with configured values for enabling Kyverno plugin there

