### PR TITLE
Don't let users install applications from the GitOps catalog that won't work on k3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To make a new application available for installation, you'll need to:
     - Security
     - Storage
     - Testing
+  - **k3d**: set to `false` if the application can't be installed on a k3d cluster. If omitted, we assume it can be installed on a k3d cluster.
 - Create a new directory with your new application's name in your fork.
   - Add, and organize your Argo CD gitops file(s) into it, if any.
 - Create a pull request with the changes from your branch to our main branch.

--- a/index.yaml
+++ b/index.yaml
@@ -28,6 +28,7 @@ apps:
     description: "Datadog's SaaS-based infrastructure monitoring provides metrics, visualizations, and alerting to ensure your engineering teams can maintain and optimize your cloud or hybrid environments."
     categories:
       - Observability
+    k3d: false
 
   - name: goldilocks
     displayName: Goldilocks


### PR DESCRIPTION
[Linked issue](https://github.com/kubefirst/kubefirst/issues/1810)

-  added **k3d** field to `index.yaml`
   - if `false` the application can't be installed on a k3d cluster. 
   - If omitted, we assume it can be installed 