### PR TITLE
Use new catalog features in Kratix offering

### DIFF
--- a/kratix/application.yaml
+++ b/kratix/application.yaml
@@ -4,58 +4,54 @@ kind: Application
 metadata:
   name: kratix
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: '10'
 spec:
   project: default
   source:
-    repoURL: 'https://github.com/syntasso/kratix'
-    path: charts/kratix
+    repoURL: "https://github.com/syntasso/helm-charts.git"
+    path: kratix
     targetRevision: HEAD
-  # helm:
-  #   values: |
-  #     # You will need to register a Destination where Kratix can
-  #     # schedule resources. This Destination is a State Store that
-  #     # represents a location where you want to deploy declared
-  #     # resources.
-  #     #
-  #     # In order for Kratix to write any declared resources to this
-  #     # Destination, you will also need to provide configuration
-  #     # via a State Store object.
-  #     #
-  #     # For more details, please see:
-  #     # https://kratix.io/docs/main/reference/destinations/intro
-  #     destinations:
-  #       # This represents the Git repository used by KubeFirst.
-  #       # It depends on the State Store below.
-  #       - name: platform
-  #         namespace: kratix-platform-system
-  #         labels:
-  #           type: platform
-  #         stateStoreRef:
-  #            name: default
-  #            kind: GitStateStore
-  #     stateStores:
-  #       # This requires:
-  #       #  1. The correct Git URL used by K1 and
-  #       #  2. A secret with the necessary values called `default-git-secret`
-  #       #
-  #       #  These values are available or can be generated with the details
-  #       #  in Terraform within the atlantis_secrets` resource.
-  #       #
-  #       # Docs:
-  #       #   https://kratix.io/docs/main/reference/statestore/gitstatestore
-  #       - kind: GitStateStore
-  #         name: default
-  #         namespace: kratix-platform-system
-  #         secretRef:
-  #           name: default-git-secret
-  #         url: https://github.com/<your_username>/gitops.
-  #         path: registry/kratix
+    helm:
+      values: |
+        destinations:
+        # Registers the current cluster as a destination for Kratix
+        # Points at GitStateStore by default
+        - name: platform
+          namespace: kratix-platform-system
+          labels:
+            environment: platform
+          stateStoreRef:
+            name: default
+            kind: GitStateStore
+        stateStores:
+        # Default BucketStateStore is the MinIO provided by KubeFirst
+        - kind: BucketStateStore
+          name: default
+          namespace: kratix-platform-system
+          secretRef:
+            name: default-bucket-secret
+          endpoint: minio.minio.svc.cluster.local:9000
+          bucket: kratix
+          insecure: true
+        # Default GitStateStore is the repo created by KubeFirst
+        - kind: GitStateStore
+          name: default
+          namespace: kratix-platform-system
+          secretRef:
+            name: default-git-secret
+          url: <GITOPS_REPO_GIT_URL>
+          path: kratix
   destination:
-    server: 'https://kubernetes.default.svc'
+    server: "https://kubernetes.default.svc"
     namespace: kratix-platform-system
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 5m0s
+        factor: 2

--- a/kratix/external-secrets.yaml
+++ b/kratix/external-secrets.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: kratix-git-access
+spec:
+  target:
+    name: default-git-secret
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: "10s"
+  data:
+    - remoteRef:
+        key: ci-secrets
+        property: BASIC_AUTH_USER
+      secretKey: username
+    - remoteRef:
+        key: ci-secrets
+        property: PERSONAL_ACCESS_TOKEN
+      secretKey: password
+---
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: kratix-bucket-access
+spec:
+  target:
+    name: default-bucket-secret
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: "10s"
+  data:
+    - remoteRef:
+        key: minio
+        property: accesskey
+      secretKey: accessKeyID
+    - remoteRef:
+        key: minio
+        property: secretkey
+      secretKey: secretAccessKey

--- a/kratix/platform-reconciler.yaml
+++ b/kratix/platform-reconciler.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: default-git-dependencies
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_GIT_URL>
+    path: kratix/platform/dependencies
+    targetRevision: HEAD
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 5m0s
+        factor: 2
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: default-git-resources
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_GIT_URL>
+    path: kratix/platform/resources
+    targetRevision: HEAD
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        maxDuration: 5m0s
+        factor: 2

--- a/kratix/wait.yaml
+++ b/kratix/wait.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-kratix-bucket
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  template:
+    spec:
+      serviceAccountName: minio-create-kratix-bucket
+      initContainers:
+        - name: wait-for-minio
+          image: bitnami/kubectl:1.20.10
+          command:
+            [
+              "sh",
+              "-c",
+              "kubectl wait --for=condition=Complete --timeout=120s -n minio job -l job-name=wait-minio-buckets",
+            ]
+      containers:
+        - name: minio-event-configuration
+          image: minio/mc:RELEASE.2023-06-06T13-48-56Z
+          command: ["mc", "mb", "--ignore-existing", "minio/kratix"]
+          env:
+            - name: MC_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: default-bucket-secret
+                  key: accessKeyID
+            - name: MC_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: default-bucket-secret
+                  key: secretAccessKey
+            - name: MC_ENDPOINT
+              value: minio.minio.svc.cluster.local:9000
+            - name: MC_HOST_minio
+              value: "http://$(MC_ACCESS_KEY):$(MC_SECRET_KEY)@$(MC_ENDPOINT)"
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: minio-create-kratix-bucket
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+rules:
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: minio-create-kratix-bucket
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: minio-create-kratix-bucket
+subjects:
+  - kind: ServiceAccount
+    name: minio-create-kratix-bucket
+    namespace: kratix-platform-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio-create-kratix-bucket
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"


### PR DESCRIPTION
This PR is based on pairing with @jarededwards and @johndietz to apply the awesome new catalog features including tokens as described [here](https://github.com/kubefirst/gitops-catalog/blob/main/README.md#kubefirst-tokens).

This has been tested locally but will require of course a run through via the proper catalog.