### PR TITLE
<GITHUB_HOST> is too broad, updating to github.com/<GITHUB_OWNER>/gitops

### DIFF
--- a/kratix/application.yaml
+++ b/kratix/application.yaml
@@ -38,7 +38,7 @@ spec:
           namespace: kratix-platform-system
           secretRef:
             name: default-git-secret
-          url: "https://<GITHUB_HOST>/<GITHUB_OWNER>/gitops"
+          url: "<GITHUB_HOST>"
           path: kratix
   destination:
     server: "https://kubernetes.default.svc"

--- a/kratix/external-secrets.yaml
+++ b/kratix/external-secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: kratix-git-access
+  namespace: kratix-platform-system
 spec:
   target:
     name: default-git-secret
@@ -24,6 +25,7 @@ apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: kratix-bucket-access
+  namespace: kratix-platform-system
 spec:
   target:
     name: default-bucket-secret

--- a/kratix/platform-reconciler.yaml
+++ b/kratix/platform-reconciler.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: "git@<GITHUB_HOST>:<GITHUB_OWNER>/gitops.git"
+    repoURL: "git@github.com:<GITHUB_OWNER>/gitops.git"
     path: kratix/platform/dependencies
     targetRevision: HEAD
     directory:
@@ -33,7 +33,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: "git@<GITHUB_HOST>:<GITHUB_OWNER>/gitops.git"
+    repoURL: "git@github.com:<GITHUB_OWNER>/gitops.git"
     path: kratix/platform/resources
     targetRevision: HEAD
     directory:

--- a/kratix/wait.yaml
+++ b/kratix/wait.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: minio-create-kratix-bucket
+  namespace: kratix-platform-system
   annotations:
     argocd.argoproj.io/sync-wave: "100"
 spec:
@@ -75,5 +76,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: minio-create-kratix-bucket
+  namespace: kratix-platform-system
   annotations:
     argocd.argoproj.io/sync-wave: "10"


### PR DESCRIPTION
Just tested and have seen that `GITHUB_HOST` does more than expect:
![image](https://github.com/kubefirst/gitops-catalog/assets/1557346/e3ad65e1-21f5-4a66-8c4e-879edf25bf0e)
![image](https://github.com/kubefirst/gitops-catalog/assets/1557346/ec2fd3a7-3d06-4ad8-a593-a225f0accc91)


This change chooses to hardcode github.com as we are already limited to that until the next update comes, but if you all would rather change the meaning of `<GITHUB_HOST>` that works too!

Please let me know if my edits seems out of place based on comparing the screenshots and the code as well 🙇 