### PR TITLE
update helm chart version

### DIFF
--- a/datadog-agent/components/datadog-agent/application.yaml
+++ b/datadog-agent/components/datadog-agent/application.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     chart: datadog
     repoURL: https://helm.datadoghq.com
-    targetRevision: 3.1.10
+    targetRevision: 3.57.3
     helm:
       releaseName: datadog
       values: |


### PR DESCRIPTION
Some DataDog features require more modern versions of agents.

I have updated this in a cluster I am administering -- and it enabled these features.

![datadog_notice](https://github.com/kubefirst/gitops-catalog/assets/4925392/80e90791-9387-410d-a00d-11372392e678)
