### PR TITLE
add kubelet-insecure-tls arg + warning on using it for metrics server

### DIFF
--- a/metrics-server/components/metrics-server/application.yaml
+++ b/metrics-server/components/metrics-server/application.yaml
@@ -12,6 +12,11 @@ spec:
     repoURL: 'https://kubernetes-sigs.github.io/metrics-server'
     targetRevision: 3.12.0
     chart: metrics-server
+    # It's not suggested to run in production with this parameter: you should deploy a signed certificate for kubelet instead
+    helm:
+      values: |
+        args:
+          - --kubelet-insecure-tls
   destination:
     name: <CLUSTER_DESTINATION>
     namespace: metrics-server


### PR DESCRIPTION
Without it, since kubefirst don't generate custom signed certificate for kubelet, metrics server will generate the 'failed to verify certificate: x509: cannot validate certificate for XXX.XXX.X.X because it doesn't contain any IP SANs' error and won't work at all.