### PR TITLE
fix: update kubedoom chart address

### DIFF
--- a/kubedoom/components/kubedoom/application.yaml
+++ b/kubedoom/components/kubedoom/application.yaml
@@ -13,7 +13,7 @@ spec:
   project: <PROJECT>
   source:
     chart: kubedoom
-    repoURL: https://christianknell.github.io/helm-charts
+    repoURL: https://charts.christianhuth.de
     targetRevision: 1.0.0
     helm:
       releaseName: my-release


### PR DESCRIPTION
The Kubedoom chart address changed in March 2024 (see [commit](https://github.com/christianhuth/helm-charts/commit/f83634fe667966a72b3007c39d691dbb61a1c4f3)).

I don't know if this hasn't been working since then or if no one's using it, but I tried today and it didn't work. This fixed it in my `gitops` repo.